### PR TITLE
Set entrypoints and automatically convert Docker to OCI media types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+gazelle:
+	bzl run //release:gazelle
+
+release-internal:
+	bzl build //release:release
+	bzl run //cmd/ocitool -- push-blob --ref "registry.ddbuild.io/public/rules-oci:latest" --file $(shell bzl info bazel-bin)/release/release.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-gazelle:
-	bzl run //release:gazelle
-
-release-internal:
-	bzl build //release:release
-	bzl run //cmd/ocitool -- push-blob --ref "registry.ddbuild.io/public/rules-oci:latest" --file $(shell bzl info bazel-bin)/release/release.tar.gz

--- a/cmd/ocitool/BUILD.bazel
+++ b/cmd/ocitool/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//internal/flagutil:go_default_library",
         "//internal/tarutil:go_default_library",
         "//pkg/blob:go_default_library",
+        "//pkg/jsonutil:go_default_library",
         "//pkg/layer:go_default_library",
         "//pkg/ociutil:go_default_library",
         "@bazel_gazelle//rule:go_default_library",

--- a/cmd/ocitool/main.go
+++ b/cmd/ocitool/main.go
@@ -102,6 +102,9 @@ var app = &cli.App{
 				&cli.StringFlag{
 					Name: "out-layout",
 				},
+				&cli.StringFlag{
+					Name: "entrypoint",
+				},
 			},
 		},
 		{

--- a/oci/push.bzl
+++ b/oci/push.bzl
@@ -46,7 +46,7 @@ def _oci_push_impl(ctx):
         --layout-relative {root} \\
         --desc {desc} \\
         --target-ref {ref} \\
-        --parent-tag {tag} \\
+        --parent-tag \"{tag}\" \\
         {headers} \\
         {xheaders} \\
         """.format(

--- a/pkg/jsonutil/BUILD.bazel
+++ b/pkg/jsonutil/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["json.go"],
+    importpath = "github.com/DataDog/rules_oci/pkg/jsonutil",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/jsonutil/json.go
+++ b/pkg/jsonutil/json.go
@@ -1,0 +1,17 @@
+package jsonutil
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// DecodeFromFile is a helper to read json from a file into a struct easily.
+func DecodeFromFile(filePath string, inf interface{}) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return json.NewDecoder(file).Decode(inf)
+}

--- a/pkg/layer/BUILD.bazel
+++ b/pkg/layer/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "@com_github_containerd_containerd//content:go_default_library",
         "@com_github_containerd_containerd//errdefs:go_default_library",
         "@com_github_containerd_containerd//images:go_default_library",
+        "@com_github_containerd_containerd//images/converter:go_default_library",
         "@com_github_containerd_containerd//reference/docker:go_default_library",
         "@com_github_opencontainers_go_digest//:go_default_library",
         "@com_github_opencontainers_image_spec//specs-go/v1:go_default_library",

--- a/pkg/layer/append.go
+++ b/pkg/layer/append.go
@@ -8,20 +8,20 @@ import (
 	"github.com/DataDog/rules_oci/pkg/ociutil"
 
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images/converter"
 	dreference "github.com/containerd/containerd/reference/docker"
-
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func AppendLayers(ctx context.Context, store content.Store, desc ocispec.Descriptor, layers []ocispec.Descriptor, annotations map[string]string, created time.Time) (ocispec.Descriptor, ocispec.Descriptor, error) {
+func AppendLayers(ctx context.Context, store content.Store, baseManifestDesc ocispec.Descriptor, layers []ocispec.Descriptor, annotations map[string]string, created time.Time, entrypoint []string) (ocispec.Descriptor, ocispec.Descriptor, error) {
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
 
-	manifest, err := ociutil.ImageManifestFromProvider(ctx, store, desc)
+	manifest, err := ociutil.ImageManifestFromProvider(ctx, store, baseManifestDesc)
 	if err != nil {
-		return ocispec.Descriptor{}, ocispec.Descriptor{}, fmt.Errorf("no image manifest (%v) in store: %w", desc, err)
+		return ocispec.Descriptor{}, ocispec.Descriptor{}, fmt.Errorf("no image manifest (%v) in store: %w", baseManifestDesc, err)
 	}
 
 	imageConfig, err := ociutil.ImageConfigFromProvider(ctx, store, manifest.Config)
@@ -29,14 +29,14 @@ func AppendLayers(ctx context.Context, store content.Store, desc ocispec.Descrip
 		return ocispec.Descriptor{}, ocispec.Descriptor{}, fmt.Errorf("no image config (%v) in store: %w", manifest.Config, err)
 	}
 
-	baseRef := desc.Annotations[ocispec.AnnotationRefName]
+	baseRef := baseManifestDesc.Annotations[ocispec.AnnotationRefName]
 
 	createdAnnotation := created.Format(time.RFC3339)
 	annotations[ocispec.AnnotationCreated] = createdAnnotation
 
 	// FIXME: add labels attribute to set this separately
 	imageConfig.Config.Labels = annotations
-	desc.Annotations = annotations
+	baseManifestDesc.Annotations = annotations
 	manifest.Annotations = annotations
 	imageConfig.Created = &created
 
@@ -70,19 +70,24 @@ func AppendLayers(ctx context.Context, store content.Store, desc ocispec.Descrip
 			}
 
 			if _, ok := layer.Annotations[ociutil.AnnotationBaseImageDigest]; !ok {
-				layer.Annotations[ociutil.AnnotationBaseImageDigest] = desc.Digest.String()
+				layer.Annotations[ociutil.AnnotationBaseImageDigest] = baseManifestDesc.Digest.String()
 			}
+
+			layer.MediaType = converter.ConvertDockerMediaTypeToOCI(layer.MediaType)
 
 			manifest.Layers[idx] = layer
 		}
 	}
 
 	// we're OCI now
-	desc.MediaType = ocispec.MediaTypeImageManifest
-	manifest.MediaType = desc.MediaType
+	baseManifestDesc.MediaType = ocispec.MediaTypeImageManifest
+	manifest.MediaType = baseManifestDesc.MediaType
 	// Append after we add the base image labels
 	manifest.Layers = append(manifest.Layers, layers...)
 	imageConfig.RootFS.DiffIDs = append(imageConfig.RootFS.DiffIDs, diffIDs...)
+
+	imageConfig.Author = "rules_oci"
+	imageConfig.Config.Entrypoint = entrypoint
 
 	newConfig, err := ociutil.IngestorJSONEncode(ctx, store, ocispec.MediaTypeImageConfig, imageConfig)
 	if err != nil {


### PR DESCRIPTION
Add an `entrypoint` attribute to `oci_image`.

Automatically convert Docker media types to OCI media types, as some registry implementations don't support mixing media types.