### PR TITLE
Post Push Hooks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,6 +96,11 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
 
+load("@com_github_datadog_rules_oci//oci:toolchain.bzl", "registry_post_push_hooks")
+registry_post_push_hooks(
+    name = "oci_push_hooks",
+)
+
 register_toolchains(
     "@com_github_datadog_rules_oci//:oci_local_toolchain",
 )

--- a/bin/BUILD.bazel
+++ b/bin/BUILD.bazel
@@ -1,4 +1,7 @@
 load("//oci:toolchain.bzl", "create_compiled_oci_toolchains")
+load("@oci_push_hooks//:defs.bzl", "POST_PUSH_HOOKS")
+
+exports_files(glob(["*"]))
 
 filegroup(
     name = "bin-files",
@@ -9,4 +12,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-create_compiled_oci_toolchains(name = "oci_toolchain")
+create_compiled_oci_toolchains(
+    name = "oci_toolchain",
+    post_push_hooks = POST_PUSH_HOOKS,
+)

--- a/oci/push.bzl
+++ b/oci/push.bzl
@@ -50,7 +50,7 @@ def _oci_push_impl(ctx):
         {headers} \\
         {xheaders} \\
 
-        export OCI_REFERENCE={ref}
+        export OCI_REFERENCE={ref}@$(cat {digest})
         {post_scripts}
         """.format(
             root = ctx.bin_dir.path,
@@ -63,6 +63,7 @@ def _oci_push_impl(ctx):
             headers = headers,
             xheaders = xheaders,
             post_scripts = "\n".join(["./" + hook.short_path for hook in toolchain.post_push_hooks]),
+            digest = digest_file.short_path,
         ),
         output = ctx.outputs.executable,
         is_executable = True,
@@ -72,7 +73,7 @@ def _oci_push_impl(ctx):
         DefaultInfo(
             runfiles = ctx.runfiles(
                 files = layout.files.to_list() +
-                        [toolchain.sdk.ocitool, ctx.attr.manifest[OCIDescriptor].descriptor_file, layout.blob_index] + toolchain.post_push_hooks,
+                        [toolchain.sdk.ocitool, ctx.attr.manifest[OCIDescriptor].descriptor_file, layout.blob_index, digest_file] + toolchain.post_push_hooks,
             ),
         ),
         OCIReferenceInfo(

--- a/oci/push.bzl
+++ b/oci/push.bzl
@@ -49,6 +49,9 @@ def _oci_push_impl(ctx):
         --parent-tag \"{tag}\" \\
         {headers} \\
         {xheaders} \\
+
+        export OCI_REFERENCE={ref}
+        {post_scripts}
         """.format(
             root = ctx.bin_dir.path,
             tool = toolchain.sdk.ocitool.short_path,
@@ -59,6 +62,7 @@ def _oci_push_impl(ctx):
             debug = str(ctx.attr._debug[DebugInfo].debug),
             headers = headers,
             xheaders = xheaders,
+            post_scripts = "\n".join(["./" + hook.short_path for hook in toolchain.post_push_hooks]),
         ),
         output = ctx.outputs.executable,
         is_executable = True,
@@ -68,7 +72,7 @@ def _oci_push_impl(ctx):
         DefaultInfo(
             runfiles = ctx.runfiles(
                 files = layout.files.to_list() +
-                        [toolchain.sdk.ocitool, ctx.attr.manifest[OCIDescriptor].descriptor_file, layout.blob_index],
+                        [toolchain.sdk.ocitool, ctx.attr.manifest[OCIDescriptor].descriptor_file, layout.blob_index] + toolchain.post_push_hooks,
             ),
         ),
         OCIReferenceInfo(


### PR DESCRIPTION
After pushing an image, run a list of post push hooks where the image reference can be accessed at the `OCI_REFERENCE` env variable. This is useful for image signing as the tool can be run against the digest in CI without any additional configuration.