### PR TITLE
Change Go module to github.com/DataDog/rules_oci_go

### DIFF
--- a/cmd/ocitool/BUILD.bazel
+++ b/cmd/ocitool/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
         "push_cmd.go",
         "pushblob_cmd.go",
     ],
-    importpath = "github.com/DataDog/rules_oci/cmd/ocitool",
+    importpath = "github.com/DataDog/rules_oci_go/cmd/ocitool",
     visibility = ["//visibility:public"],
     deps = [
         "//internal/flagutil:go_default_library",

--- a/cmd/ocitool/appendlayer_cmd.go
+++ b/cmd/ocitool/appendlayer_cmd.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/rules_oci/internal/flagutil"
-	"github.com/DataDog/rules_oci/pkg/blob"
-	"github.com/DataDog/rules_oci/pkg/jsonutil"
-	"github.com/DataDog/rules_oci/pkg/layer"
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/internal/flagutil"
+	"github.com/DataDog/rules_oci_go/pkg/blob"
+	"github.com/DataDog/rules_oci_go/pkg/jsonutil"
+	"github.com/DataDog/rules_oci_go/pkg/layer"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"

--- a/cmd/ocitool/createlayer_cmd.go
+++ b/cmd/ocitool/createlayer_cmd.go
@@ -9,9 +9,9 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/DataDog/rules_oci/internal/flagutil"
-	"github.com/DataDog/rules_oci/internal/tarutil"
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/internal/flagutil"
+	"github.com/DataDog/rules_oci_go/internal/tarutil"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cmd/ocitool/desc_helpers.go
+++ b/cmd/ocitool/desc_helpers.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/DataDog/rules_oci/pkg/blob"
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/pkg/blob"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	"github.com/containerd/containerd/content"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cmd/ocitool/digest_cmd.go
+++ b/cmd/ocitool/digest_cmd.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/ocitool/gen_cmd.go
+++ b/cmd/ocitool/gen_cmd.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	"github.com/bazelbuild/bazel-gazelle/rule"
 	"github.com/containerd/containerd/images"

--- a/cmd/ocitool/index_cmd.go
+++ b/cmd/ocitool/index_cmd.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/DataDog/rules_oci/internal/flagutil"
-	"github.com/DataDog/rules_oci/pkg/blob"
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/internal/flagutil"
+	"github.com/DataDog/rules_oci_go/pkg/blob"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	ocispecv "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cmd/ocitool/main.go
+++ b/cmd/ocitool/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/DataDog/rules_oci/internal/flagutil"
+	"github.com/DataDog/rules_oci_go/internal/flagutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/ocitool/manifest_cmd.go
+++ b/cmd/ocitool/manifest_cmd.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/DataDog/rules_oci/pkg/blob"
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/pkg/blob"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	ocispecv "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cmd/ocitool/publishrules_cmd.go
+++ b/cmd/ocitool/publishrules_cmd.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	ocispecv "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cmd/ocitool/pull_cmd.go
+++ b/cmd/ocitool/pull_cmd.go
@@ -3,7 +3,7 @@ package main
 import (
 	"golang.org/x/sync/semaphore"
 
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	"github.com/containerd/containerd/images"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cmd/ocitool/push_cmd.go
+++ b/cmd/ocitool/push_cmd.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/DataDog/rules_oci/internal/flagutil"
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/internal/flagutil"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"

--- a/cmd/ocitool/pushblob_cmd.go
+++ b/cmd/ocitool/pushblob_cmd.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	"github.com/urfave/cli/v2"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DataDog/rules_oci
+module github.com/DataDog/rules_oci_go
 
 go 1.18
 

--- a/internal/flagutil/BUILD.bazel
+++ b/internal/flagutil/BUILD.bazel
@@ -3,6 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["kv.go"],
-    importpath = "github.com/DataDog/rules_oci/internal/flagutil",
+    importpath = "github.com/DataDog/rules_oci_go/internal/flagutil",
     visibility = ["//:__subpackages__"],
 )

--- a/internal/set/BUILD.bazel
+++ b/internal/set/BUILD.bazel
@@ -3,6 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["string.go"],
-    importpath = "github.com/DataDog/rules_oci/internal/set",
+    importpath = "github.com/DataDog/rules_oci_go/internal/set",
     visibility = ["//:__subpackages__"],
 )

--- a/internal/tarutil/BUILD.bazel
+++ b/internal/tarutil/BUILD.bazel
@@ -3,6 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["tarappend.go"],
-    importpath = "github.com/DataDog/rules_oci/internal/tarutil",
+    importpath = "github.com/DataDog/rules_oci_go/internal/tarutil",
     visibility = ["//:__subpackages__"],
 )

--- a/pkg/blob/BUILD.bazel
+++ b/pkg/blob/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["blobindex.go"],
-    importpath = "github.com/DataDog/rules_oci/pkg/blob",
+    importpath = "github.com/DataDog/rules_oci_go/pkg/blob",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_containerd_containerd//content:go_default_library",

--- a/pkg/credhelper/BUILD.bazel
+++ b/pkg/credhelper/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["docker.go"],
-    importpath = "github.com/DataDog/rules_oci/pkg/credhelper",
+    importpath = "github.com/DataDog/rules_oci_go/pkg/credhelper",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_containerd_containerd//errdefs:go_default_library",

--- a/pkg/deb2layer/BUILD.bazel
+++ b/pkg/deb2layer/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["deb.go"],
-    importpath = "github.com/DataDog/rules_oci/pkg/deb2layer",
+    importpath = "github.com/DataDog/rules_oci_go/pkg/deb2layer",
     visibility = ["//visibility:public"],
     deps = ["@com_github_blakesmith_ar//:go_default_library"],
 )

--- a/pkg/jsonutil/BUILD.bazel
+++ b/pkg/jsonutil/BUILD.bazel
@@ -3,6 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["json.go"],
-    importpath = "github.com/DataDog/rules_oci/pkg/jsonutil",
+    importpath = "github.com/DataDog/rules_oci_go/pkg/jsonutil",
     visibility = ["//visibility:public"],
 )

--- a/pkg/layer/BUILD.bazel
+++ b/pkg/layer/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "append.go",
         "appendlayeringester.go",
     ],
-    importpath = "github.com/DataDog/rules_oci/pkg/layer",
+    importpath = "github.com/DataDog/rules_oci_go/pkg/layer",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ociutil:go_default_library",

--- a/pkg/layer/append.go
+++ b/pkg/layer/append.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/DataDog/rules_oci/pkg/ociutil"
+	"github.com/DataDog/rules_oci_go/pkg/ociutil"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images/converter"

--- a/pkg/ociutil/BUILD.bazel
+++ b/pkg/ociutil/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
         "tar.go",
         "writer.go",
     ],
-    importpath = "github.com/DataDog/rules_oci/pkg/ociutil",
+    importpath = "github.com/DataDog/rules_oci_go/pkg/ociutil",
     visibility = ["//visibility:public"],
     deps = [
         "//internal/set:go_default_library",

--- a/pkg/ociutil/handler.go
+++ b/pkg/ociutil/handler.go
@@ -3,7 +3,7 @@ package ociutil
 import (
 	"context"
 
-	"github.com/DataDog/rules_oci/internal/set"
+	"github.com/DataDog/rules_oci_go/internal/set"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"

--- a/pkg/ociutil/push.go
+++ b/pkg/ociutil/push.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/DataDog/rules_oci/pkg/credhelper"
+	"github.com/DataDog/rules_oci_go/pkg/credhelper"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"


### PR DESCRIPTION
This is so that Gazelle can actually import the repository as a Go repository when we already have `@com_github_datadog_rules_oci` used for the rules themselves. Gazelle will try to generate the Go repository name based on the Go module name, so we need the Go module name to be distinct from the rules name.

I've tested this in a repo that is already using the `@com_github_datadog_rules_oci` rules label, by adding a dependency on `github.com/DataDog/rules_oci_go` (with a `replace` to `github.com/abayer/rules_oci`) and it works. =)