### PR TITLE
Fix bug in which pushes silently fail

### DIFF
--- a/oci/push.bzl
+++ b/oci/push.bzl
@@ -38,7 +38,8 @@ def _oci_push_impl(ctx):
         xheaders = xheaders + " --x_meta_headers={}={}".format(k, v)
 
     ctx.actions.write(
-        content = """
+        content = """#!/usr/bin/env bash
+        set -euo pipefail
         {tool}  \\
         --layout {layout} \\
         --debug={debug} \\


### PR DESCRIPTION
I observed a case where this rule succeeded even though the push failed with an error message like
```
failed to push child content to registry: failed to create reader from ingestor: not found
// build continues...
```

I believe the reason is that the push command is not the last command in the script, so errors are suppressed. This PR adds the necessary flags for safe bash.