### PR TITLE
Add oci_rebase_image rule

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -122,3 +122,28 @@ oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-headers">headers<
 | <a id="oci_push-x_meta_headers"></a>x_meta_headers |  (optional) A list of key/values to to be sent to the registry as headers with an X-Meta- prefix.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 
 
+<a id="#oci_rebase_image"></a>
+
+## oci_rebase_image
+
+<pre>
+oci_rebase_image(<a href="#oci_rebase_image-name">name</a>, <a href="#oci_rebase_image-arch">arch</a>, <a href="#oci_rebase_image-new_base">new_base</a>, <a href="#oci_rebase_image-old_base">old_base</a>, <a href="#oci_rebase_image-original">original</a>, <a href="#oci_rebase_image-os">os</a>)
+</pre>
+
+Creates a new image manifest and config by taking the layers of an `original` image, an `old_base` image,
+    and a `new_base`, and appending the layers of the `original` image, after the layers shared with the `old_base` image,
+    onto the existing manifest, config, and layers of the `new_base` image.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="oci_rebase_image-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="oci_rebase_image-arch"></a>arch |  Used to extract a manifest from original, old_base, or new_base if they are indexes   | String | optional | "" |
+| <a id="oci_rebase_image-new_base"></a>new_base |  An OCI image the original image's non-base layers will be appended to, as defined by oci_pull or oci_image   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="oci_rebase_image-old_base"></a>old_base |  An OCI image the original image is built on top of, as defined by oci_pull or oci_image   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="oci_rebase_image-original"></a>original |  An OCI image, as defined by oci_pull or oci_image   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="oci_rebase_image-os"></a>os |  Used to extract a manifest from original, old_base, or new_base if they are indexes   | String | optional | "" |
+
+

--- a/go/cmd/ocitool/BUILD.bazel
+++ b/go/cmd/ocitool/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "pull_cmd.go",
         "push_cmd.go",
         "pushblob_cmd.go",
+        "rebaseimage_cmd.go",
     ],
     importpath = "github.com/DataDog/rules_oci/go/cmd/ocitool",
     visibility = ["//visibility:public"],

--- a/go/cmd/ocitool/desc_helpers.go
+++ b/go/cmd/ocitool/desc_helpers.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/DataDog/rules_oci/go/pkg/blob"
 	"github.com/DataDog/rules_oci/go/pkg/ociutil"
-
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -61,4 +62,69 @@ func LoadLocalProviders(layoutPaths []string, relPath string) ([]content.Provide
 	}
 
 	return providers, nil
+}
+
+// loadManifestForImage loads the descriptor in the given file and returns the appropriate manifest for that descriptor
+// and the given OS and architecture.
+func loadManifestForImage(ctx context.Context, allLocalProviders content.Provider, descriptorFile string, os string, arch string) (ocispec.Descriptor, error) {
+	// Read the descriptor, at this point we don't know if it's an image
+	// manifest or index, so it's an unknown media type.
+	unknownDesc, err := ociutil.ReadDescriptorFromFile(descriptorFile)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	targetPlatform := ocispec.Platform{
+		OS:           os,
+		Architecture: arch,
+	}
+	targetPlatformMatch := platforms.Only(targetPlatform)
+
+	// Resolve the unknown descriptor into an image manifest, if an index
+	// match the requested platform.
+	var manifestDesc ocispec.Descriptor
+	if images.IsIndexType(unknownDesc.MediaType) {
+		index, err := ociutil.ImageIndexFromProvider(ctx, allLocalProviders, unknownDesc)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+
+		manifestDesc, err = ociutil.ManifestFromIndex(index, targetPlatformMatch)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+
+		if !targetPlatformMatch.Match(*manifestDesc.Platform) {
+			return ocispec.Descriptor{}, fmt.Errorf("invalid platform, expected %v, recieved %v", targetPlatform, *manifestDesc.Platform)
+		}
+
+	} else if images.IsManifestType(unknownDesc.MediaType) {
+		manifestDesc = unknownDesc
+
+		if ociutil.IsEmptyPlatform(manifestDesc.Platform) {
+			platform, err := ociutil.ResolvePlatformFromDescriptor(ctx, allLocalProviders, manifestDesc)
+			if err != nil {
+				return ocispec.Descriptor{}, fmt.Errorf("no platform for base: %w", err)
+			}
+
+			manifestDesc.Platform = &platform
+		}
+	} else {
+		return ocispec.Descriptor{}, fmt.Errorf("unknown base image type %q", unknownDesc.MediaType)
+	}
+
+	// Original comment: Copy the annotation with the original reference of the base image
+	// so that we know when we push the image where those layers come from
+	// for mount calls.
+	//
+	// This isn't true; we don't look at AnnotationRefName in ociutil.CopyContent
+	if manifestDesc.Annotations == nil {
+		manifestDesc.Annotations = make(map[string]string)
+	}
+	baseRef, ok := unknownDesc.Annotations[ocispec.AnnotationRefName]
+	if ok {
+		manifestDesc.Annotations[ocispec.AnnotationRefName] = baseRef
+	}
+
+	return manifestDesc, nil
 }

--- a/go/cmd/ocitool/main.go
+++ b/go/cmd/ocitool/main.go
@@ -116,6 +116,45 @@ var app = &cli.App{
 			},
 		},
 		{
+			Name:   "rebase-image",
+			Action: RebaseImageCmd,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "original",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:     "old-base",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:     "new-base",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name: "bazel-version-file",
+				},
+				&cli.StringFlag{
+					Name: "outd",
+				},
+				&cli.StringFlag{
+					Name: "os",
+				},
+				&cli.StringFlag{
+					Name: "arch",
+				},
+				&cli.StringFlag{
+					Name: "out-manifest",
+				},
+				&cli.StringFlag{
+					Name: "out-config",
+				},
+				&cli.StringFlag{
+					Name: "out-layout",
+				},
+			},
+		},
+		{
 			Name:   "push",
 			Action: PushCmd,
 			Flags: []cli.Flag{

--- a/go/cmd/ocitool/rebaseimage_cmd.go
+++ b/go/cmd/ocitool/rebaseimage_cmd.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/rules_oci/go/pkg/blob"
+	"github.com/DataDog/rules_oci/go/pkg/layer"
+	"github.com/DataDog/rules_oci/go/pkg/ociutil"
+	"github.com/opencontainers/go-digest"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+func RebaseImageCmd(c *cli.Context) error {
+	localProviders, err := LoadLocalProviders(c.StringSlice("layout"), c.String("layout-relative"))
+	if err != nil {
+		return err
+	}
+
+	var stampVars map[string]string
+	bazelVersionFilePath := c.String("bazel-version-file")
+	if bazelVersionFilePath != "" {
+		file, err := os.Open(bazelVersionFilePath)
+		if err != nil {
+			return err
+		}
+
+		stampVars, err = loadStamp(file)
+		file.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	createdTimestamp := time.Unix(0, 0)
+	if timeStr, ok := stampVars["BUILD_TIMESTAMP"]; ok {
+		timeInt, err := strconv.ParseInt(timeStr, 10, 0)
+		if err != nil {
+			return err
+		}
+
+		createdTimestamp = time.Unix(timeInt, 0)
+	}
+
+	allLocalProviders := ociutil.MultiProvider(localProviders...)
+
+	originalDesc, err := loadManifestForImage(c.Context, allLocalProviders, c.String("original"), c.String("os"), c.String("arch"))
+	if err != nil {
+		return fmt.Errorf("loading descriptor for original image: %w", err)
+	}
+	log.WithField("original_desc", originalDesc).Debugf("using as original image")
+
+	oldBaseDesc, err := loadManifestForImage(c.Context, allLocalProviders, c.String("old-base"), c.String("os"), c.String("arch"))
+	if err != nil {
+		return fmt.Errorf("loading descriptor for old base image: %w", err)
+	}
+	log.WithField("old_base_desc", oldBaseDesc).Debugf("using as old base image")
+
+	newBaseDesc, err := loadManifestForImage(c.Context, allLocalProviders, c.String("new-base"), c.String("os"), c.String("arch"))
+	if err != nil {
+		return fmt.Errorf("loading descriptor for new base image: %w", err)
+	}
+	log.WithField("new_base_desc", newBaseDesc).Debugf("using as new base image")
+
+	outIngestor := layer.NewAppendIngester(c.String("out-manifest"), c.String("out-config"))
+
+	layerProvider := &blob.Index{
+		Blobs: make(map[digest.Digest]string),
+	}
+
+	newManifest, newConfig, err := layer.RebaseImage(
+		c.Context,
+		ociutil.SplitStore(outIngestor, allLocalProviders),
+		originalDesc,
+		oldBaseDesc,
+		newBaseDesc,
+		createdTimestamp,
+	)
+	if err != nil {
+		return err
+	}
+
+	layerProvider.Blobs[newManifest.Digest] = c.String("out-manifest")
+	layerProvider.Blobs[newConfig.Digest] = c.String("out-config")
+
+	err = layerProvider.WriteToFile(c.String("out-layout"))
+	if err != nil {
+		return err
+	}
+
+	err = ociutil.WriteDescriptorToFile(c.String("outd"), newManifest)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/pkg/layer/BUILD.bazel
+++ b/go/pkg/layer/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "append.go",
         "appendlayeringester.go",
+        "rebase.go",
     ],
     importpath = "github.com/DataDog/rules_oci/go/pkg/layer",
     visibility = ["//visibility:public"],

--- a/go/pkg/layer/rebase.go
+++ b/go/pkg/layer/rebase.go
@@ -1,0 +1,59 @@
+package layer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/rules_oci/go/pkg/ociutil"
+	"github.com/containerd/containerd/content"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// RebaseImage takes an original image, its current base image, and a new base image, and returns a new image with the old base image replaced with the new one.
+func RebaseImage(ctx context.Context, store content.Store, originalImageDesc ocispec.Descriptor, oldBaseImageDesc ocispec.Descriptor, newBaseImageDesc ocispec.Descriptor, createdTimestamp time.Time) (ocispec.Descriptor, ocispec.Descriptor, error) {
+	originalManifest, err := ociutil.ImageManifestFromProvider(ctx, store, originalImageDesc)
+	if err != nil {
+		return ocispec.Descriptor{}, ocispec.Descriptor{}, fmt.Errorf("no image manifest (%v) in store: %w", originalImageDesc, err)
+	}
+
+	originalImageConfig, err := ociutil.ImageConfigFromProvider(ctx, store, originalManifest.Config)
+	if err != nil {
+		return ocispec.Descriptor{}, ocispec.Descriptor{}, fmt.Errorf("no image config (%v) in store: %w", originalManifest.Config, err)
+	}
+
+	oldBaseManifest, err := ociutil.ImageManifestFromProvider(ctx, store, oldBaseImageDesc)
+	if err != nil {
+		return ocispec.Descriptor{}, ocispec.Descriptor{}, fmt.Errorf("no image manifest (%v) in store: %w", oldBaseImageDesc, err)
+	}
+
+	if len(oldBaseManifest.Layers) > len(originalManifest.Layers) {
+		return ocispec.Descriptor{}, ocispec.Descriptor{}, fmt.Errorf("old base image (%v) has more layers than original image (%v)", oldBaseImageDesc, originalImageDesc)
+	}
+
+	for i, l := range oldBaseManifest.Layers {
+		if l.Digest != originalManifest.Layers[i].Digest {
+			return ocispec.Descriptor{}, ocispec.Descriptor{}, fmt.Errorf("layer at index %d in old base image (%v) does not match layer in original image (%v)",
+				i, oldBaseImageDesc, originalImageDesc)
+		}
+	}
+
+	// Get the original image's layers after the old base image to append to the new base image.
+	var layersToAppend []ocispec.Descriptor
+	layersToAppend = append(layersToAppend, originalManifest.Layers[len(oldBaseManifest.Layers):]...)
+
+	rebasedManifest, rebasedConfig, err := AppendLayers(ctx, store, newBaseImageDesc, layersToAppend, nil, originalImageConfig.Config.Labels, createdTimestamp, originalImageConfig.Config.Entrypoint)
+	if err != nil {
+		return ocispec.Descriptor{}, ocispec.Descriptor{}, fmt.Errorf("appending original image layers onto new base image: %w", err)
+	}
+
+	if rebasedManifest.Annotations == nil {
+		rebasedManifest.Annotations = make(map[string]string)
+	}
+
+	// Set the new base image's name and digest as the values for the OCI base image annotations.
+	rebasedManifest.Annotations[ocispec.AnnotationBaseImageName] = newBaseImageDesc.Annotations[ocispec.AnnotationRefName]
+	rebasedManifest.Annotations[ocispec.AnnotationBaseImageDigest] = newBaseImageDesc.Digest.String()
+
+	return rebasedManifest, rebasedConfig, nil
+}

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -1,6 +1,6 @@
 load(":pull.bzl", _oci_pull = "oci_pull")
 load(":push.bzl", _oci_push = "oci_push")
-load(":image.bzl", _oci_image = "oci_image", _oci_image_index = "oci_image_index", _oci_image_layer = "oci_image_layer")
+load(":image.bzl", _oci_image = "oci_image", _oci_image_index = "oci_image_index", _oci_image_layer = "oci_image_layer", _oci_rebase_image = "oci_rebase_image")
 
 oci_pull = _oci_pull
 oci_push = _oci_push
@@ -8,3 +8,4 @@ oci_push = _oci_push
 oci_image = _oci_image
 oci_image_index = _oci_image_index
 oci_image_layer = _oci_image_layer
+oci_rebase_image = _oci_rebase_image

--- a/oci/image.bzl
+++ b/oci/image.bzl
@@ -269,3 +269,109 @@ oci_image = rule(
     },
     toolchains = ["@com_github_datadog_rules_oci//oci:toolchain"],
 )
+
+def _oci_rebase_image_impl(ctx):
+    toolchain = ctx.toolchains["@com_github_datadog_rules_oci//oci:toolchain"]
+
+    layout_files = depset(None, transitive = [ctx.attr.original[OCILayout].files, ctx.attr.old_base[OCILayout].files, ctx.attr.new_base[OCILayout].files])
+
+    original_desc = get_descriptor_file(ctx, ctx.attr.original[OCIDescriptor])
+    old_base_desc = get_descriptor_file(ctx, ctx.attr.old_base[OCIDescriptor])
+    new_base_desc = get_descriptor_file(ctx, ctx.attr.new_base[OCIDescriptor])
+
+    manifest_desc_file = ctx.actions.declare_file("{}.manifest.descriptor.json".format(ctx.label.name))
+    manifest_file = ctx.actions.declare_file("{}.manifest.json".format(ctx.label.name))
+    config_file = ctx.actions.declare_file("{}.config.json".format(ctx.label.name))
+    layout_file = ctx.actions.declare_file("{}.layout.json".format(ctx.label.name))
+
+    ctx.actions.run(
+        executable = toolchain.sdk.ocitool,
+        arguments = ["--layout={}".format(m[OCILayout].blob_index.path) for m in [ctx.attr.original, ctx.attr.old_base, ctx.attr.new_base]] +
+                    [
+                        "rebase-image",
+                        "--bazel-version-file={}".format(ctx.version_file.path),
+                        "--original={}".format(original_desc.path),
+                        "--old-base={}".format(old_base_desc.path),
+                        "--new-base={}".format(new_base_desc.path),
+                        "--os={}".format(ctx.attr.os),
+                        "--arch={}".format(ctx.attr.arch),
+                        "--out-manifest={}".format(manifest_file.path),
+                        "--out-config={}".format(config_file.path),
+                        "--out-layout={}".format(layout_file.path),
+                        "--outd={}".format(manifest_desc_file.path),
+                    ],
+        inputs = [
+                     ctx.version_file,
+                     original_desc,
+                     old_base_desc,
+                     new_base_desc,
+                     ctx.attr.original[OCILayout].blob_index,
+                     ctx.attr.old_base[OCILayout].blob_index,
+                     ctx.attr.new_base[OCILayout].blob_index,
+                 ] +
+                 layout_files.to_list(),
+        outputs = [
+            manifest_file,
+            config_file,
+            layout_file,
+            manifest_desc_file,
+        ],
+    )
+
+    return [
+        OCIDescriptor(
+            descriptor_file = manifest_desc_file,
+        ),
+        OCILayout(
+            blob_index = layout_file,
+            files = depset([manifest_file, config_file, layout_file]),
+        ),
+        DefaultInfo(
+            files = depset([
+                manifest_file,
+                config_file,
+                layout_file,
+                manifest_desc_file,
+            ]),
+        ),
+    ]
+
+oci_rebase_image = rule(
+    implementation = _oci_rebase_image_impl,
+    doc = """Creates a new image manifest and config by taking the layers of an `original` image, an `old_base` image,
+    and a `new_base`, and appending the layers of the `original` image, after the layers shared with the `old_base` image,
+    onto the existing manifest, config, and layers of the `new_base` image.""",
+    attrs = {
+        "original": attr.label(
+            doc = """An OCI image, as defined by oci_pull or oci_image""",
+            mandatory = True,
+            providers = [
+                OCIDescriptor,
+                OCILayout,
+            ],
+        ),
+        "old_base": attr.label(
+            doc = """An OCI image the original image is built on top of, as defined by oci_pull or oci_image""",
+            mandatory = True,
+            providers = [
+                OCIDescriptor,
+                OCILayout,
+            ],
+        ),
+        "new_base": attr.label(
+            doc = """An OCI image the original image's non-base layers will be appended to, as defined by oci_pull or oci_image""",
+            mandatory = True,
+            providers = [
+                OCIDescriptor,
+                OCILayout,
+            ],
+        ),
+        "os": attr.string(
+            doc = "Used to extract a manifest from original, old_base, or new_base if they are indexes",
+        ),
+        "arch": attr.string(
+            doc = "Used to extract a manifest from original, old_base, or new_base if they are indexes",
+        ),
+    },
+    toolchains = ["@com_github_datadog_rules_oci//oci:toolchain"],
+)

--- a/tests/go-multiarch-image/BUILD.bazel
+++ b/tests/go-multiarch-image/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load(":go.bzl", "go_multiarch_image")
-load("@com_github_datadog_rules_oci//oci:defs.bzl", "oci_push")
+load("@com_github_datadog_rules_oci//oci:defs.bzl", "oci_push", "oci_rebase_image")
 
 go_library(
     name = "go_default_library",
@@ -32,6 +32,23 @@ oci_push(
     manifest = ":image",
     registry = "ghcr.io",
     repository = "datadog/rules_oci/hello-world",
+)
+
+oci_rebase_image(
+    name = "rebase",
+    arch = "arm64",
+    new_base = "@ubuntu_jammy//image",
+    old_base = "@ubuntu_focal//image",
+    original = ":image",
+    os = "linux",
+    visibility = ["//visibility:public"],
+)
+
+oci_push(
+    name = "push-rebase",
+    manifest = ":rebase",
+    registry = "ghcr.io",
+    repository = "datadog/rules_oci/hello-world-rebase",
 )
 
 bzl_library(

--- a/tests/test_images.bzl
+++ b/tests/test_images.bzl
@@ -8,3 +8,12 @@ def pull_test_images():
         # Latest at "focal" tag
         digest = "sha256:9d6a8699fb5c9c39cf08a0871bd6219f0400981c570894cd8cbea30d3424a31f",
     )
+
+    # TODO(abayer): Temporarily using a public image I pushed to my own gcr.io repo.
+    oci_pull(
+        name = "ubuntu_jammy",
+        registry = "gcr.io",
+        repository = "abayer-jclouds-test1/rules_oci/ubuntu",
+        # Latest at "jammy" tag
+        digest = "sha256:99f98de8a0a27a7e1b3979238d17422ae3359573bda3beed0906da7e2d42e8c3",
+    )


### PR DESCRIPTION
This rule will allow for taking an existing OCI image and replacing the given base image with a new base image, without needing to rebuild all of the other layers.