### PR TITLE
Properly handle unconfigured registries with authorization challenges

### DIFF
--- a/go/pkg/credhelper/docker.go
+++ b/go/pkg/credhelper/docker.go
@@ -112,16 +112,18 @@ func RegistryHostsFromDockerConfig() docker.RegistryHosts {
 			return nil, nil
 		}
 
-		helperName, ok := cfg.CredentialHelpers[host]
-		if !ok {
-			return nil, nil
-		}
-
 		registryHost := docker.RegistryHost{
 			Host:         host,
 			Scheme:       "https",
 			Path:         "/v2",
 			Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush,
+		}
+
+		helperName, ok := cfg.CredentialHelpers[host]
+		if !ok {
+			// If no credential helper is specified, fall back on the default behavior.
+			registryHost.Authorizer = docker.NewDockerAuthorizer()
+			return []docker.RegistryHost{registryHost}, nil
 		}
 
 		registryHost.Authorizer = docker.NewDockerAuthorizer(docker.WithAuthCreds(func(host string) (string, string, error) {


### PR DESCRIPTION
When you try to `oci_pull` an image from a registry other than one configured in `~/.docker/config.json` with a credentials helper or from the default Docker registry, the pull can fail, even if the registry shouldn't require authentication. That's because the standard Docker authorizer flow handles token challenges, and many public-facing registries allow public access but _do_ require going through a token challenge to do so. In order to pull (or push, for that matter) from such a registry, we need to have the `docker.RegistryHosts` function return an initialized `docker.RegistryHost` with `.Authorizer` set to a default `docker.NewDockerAuthorizer()` for hosts without configured credential helpers.

cc @jprobinson 