### PR TITLE
LANGTOOLS-2195 Start allowing configuration files

### DIFF
--- a/go/cmd/ocitool/main.go
+++ b/go/cmd/ocitool/main.go
@@ -43,9 +43,12 @@ var app = &cli.App{
 			Name:   "create-layer",
 			Action: CreateLayerCmd,
 			Flags: []cli.Flag{
+				&cli.PathFlag{
+					Name:  "configuration-file",
+					Usage: "Path to a configuration file. Useful when there are too many flags to pass at once.",
+				},
 				&cli.StringFlag{
-					Name:     "dir",
-					Required: true,
+					Name: "dir",
 				},
 				&cli.StringSliceFlag{
 					Name: "file",


### PR DESCRIPTION
## Context

Jira Issue: https://datadoghq.atlassian.net/browse/LANGTOOLS-2195

We've found that sometimes we want to create layers that have many
arguments. Like when we have a ton of files to map. This ends up causing
an issue where the underlying system cannot support so many arguments
and it ends up failing.

We're changing the `ocitool create-layer` command to accept a
configuration file (in JSON format) that can be used to supply arguments
to the command.

There is technically a way to solve this problem without using a JSON
file and making `ocitool create-layer` understand the different syntaxes
that Bazel uses for param files:
https://bazel.build/rules/lib/builtins/Args#use_param_file. Those
syntaxes are hard to deal with, at best. They're written for a very
specific type of CLI, and we don't seem to have an easy way to support
that.

Instead, we choose JSON as our format as it's ubiquitous, supported
natively by Bazel (so we can say `json.encode(…)` in a rule), and
supported by the Go stdlib (so we don't have to try hard to parse it).
It's not a hard requirement, but it makes implemnting support trivial.

### Why not `github.com/urfave/cli/v2/altsrc`?

There is technically a way to get configuration file support with https://pkg.go.dev/github.com/urfave/cli/v2/altsrc. It's pretty convoluted in how it works. It also requires updating all of the flags and a bunch of other book keeping. It also requires the config file to have an entry for every single flag. But complexities aside, it simply doesn't work.

In particular, we have some [`cli.Generic` flags](https://github.com/DataDog/rules_oci/blob/707e4118275c3d41620a49a5fdbb435e88a40e94/go/cmd/ocitool/main.go#L62-L69). [This check](https://github.com/urfave/cli/blob/09ac54c2f97f4249282baf266c54a09fab1bef58/altsrc/json_source_context.go#L168-L171) for `cli.Generic` flags will likely never succeed, because (as far as I know) there's no way to take some primitive value parsed from JSON masquerading as an `interface{}`, and find its `cli.Generic` methods. Even if the compiler could do that, it would almost surely be guessing which type to magic-up because once you have more than one implementation for `cli.Generic`, all bets are off without more type information.

I was going to make a note upstream, but I saw we're on an older version, and the implementation changed in v3 to support maps directly. So, I'm not even sure if this is still a problem there. Even if we did update to see if the v3 version fixed this issue, `urfave/cli` doesn't feel like the CLI package we should be using anyway. Its lack of type information means we have a bunch of bugs in our code now. We should use a different CLI package, but that's a different conversation.