### PR TITLE
Include the digest in reader failure errors

### DIFF
--- a/go/pkg/ociutil/push.go
+++ b/go/pkg/ociutil/push.go
@@ -281,7 +281,7 @@ func CopyContent(ctx context.Context, from content.Provider, to content.Ingester
 
 	reader, err := from.ReaderAt(ctx, desc)
 	if err != nil {
-		return fmt.Errorf("failed to create reader from ingestor: %w", err)
+		return fmt.Errorf("failed to create reader for '%s' from ingestor: %w", desc.Digest.String(), err)
 	}
 
 	ref := desc.Digest.String()


### PR DESCRIPTION
This error is pretty cryptic, at least this way it will let us look for things a little more
