### PR TITLE
Thread files from image's ancestors all the way through to it's output

### DIFF
--- a/oci/image.bzl
+++ b/oci/image.bzl
@@ -143,9 +143,8 @@ oci_image_index = rule(
 def _oci_image_impl(ctx):
     toolchain = ctx.toolchains["@com_github_datadog_rules_oci//oci:toolchain"]
 
-    layout = ctx.attr.base[OCILayout]
-
     base_desc = get_descriptor_file(ctx, ctx.attr.base[OCIDescriptor])
+    base_layout = ctx.attr.base[OCILayout]
 
     manifest_desc_file = ctx.actions.declare_file("{}.manifest.descriptor.json".format(ctx.label.name))
     manifest_file = ctx.actions.declare_file("{}.manifest.json".format(ctx.label.name))
@@ -177,7 +176,7 @@ def _oci_image_impl(ctx):
     ctx.actions.run(
         executable = toolchain.sdk.ocitool,
         arguments = [
-                        "--layout={}".format(layout.blob_index.path),
+                        "--layout={}".format(base_layout.blob_index.path),
                         "append-layers",
                         "--bazel-version-file={}".format(ctx.version_file.path),
                         "--base={}".format(base_desc.path),
@@ -196,10 +195,14 @@ def _oci_image_impl(ctx):
                     ["--annotations={}={}".format(k, v) for k, v in annotations.items()] +
                     ["--labels={}={}".format(k, v) for k, v in labels.items()] +
                     ["--env={}".format(env) for env in ctx.attr.env],
-        inputs = [ctx.version_file, base_desc, layout.blob_index, entrypoint_config_file] +
-                 ctx.files.layers +
+        inputs = [
+                     ctx.version_file,
+                     base_desc,
+                     base_layout.blob_index,
+                     entrypoint_config_file,
+                 ] + ctx.files.layers +
                  layer_descriptor_files +
-                 layout.files.to_list(),
+                 base_layout.files.to_list(),
         outputs = [
             manifest_file,
             config_file,
@@ -216,7 +219,7 @@ def _oci_image_impl(ctx):
             blob_index = layout_file,
             files = depset(
                 ctx.files.layers + [manifest_file, config_file, layout_file],
-                transitive = [layout.files],
+                transitive = [base_layout.files],
             ),
         ),
         DefaultInfo(

--- a/oci/image.bzl
+++ b/oci/image.bzl
@@ -214,7 +214,10 @@ def _oci_image_impl(ctx):
         ),
         OCILayout(
             blob_index = layout_file,
-            files = depset(ctx.files.layers + [manifest_file, config_file, layout_file]),
+            files = depset(
+                ctx.files.layers + [manifest_file, config_file, layout_file],
+                transitive = [layout.files],
+            ),
         ),
         DefaultInfo(
             files = depset([


### PR DESCRIPTION
As you construct images by layering them on top of one another, e.g.

```
oci_image(
   name = "image1",
   base = "@ubuntu//image",
   layers = [":layer1"],
)

oci_image(
  name = "image2",
  base = ":image1",
  layers = [":layer2"],
)
```

You want the images to keep passing the files of their ancestors along the chain.

This is not expensive (because we are using `depset`) and it will enable future improvements, in particular writing an `oci_image_tar` rule that knows how to turn an `oci_image` target into a tar file that conforms to the OCI Image Layout spec and can be loaded into local Docker. This PR sets the groundwork for that kind of functionality since, with this change, `image2`'s output in the above example will now contain all the files from `@base//image`, `layer1` and `layer2`, which are all required to create a tarball. Before this change, `image2`'s output only contains the files from `layer2`