### PR TITLE
Add config command to ocitool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bazel-rules_oci
 bazel-testlogs
 
 bin/ocitool-*
+
+.ijwb

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,14 +13,20 @@ oci_local_toolchain(
 
 buildifier(
     name = "buildifier",
-    exclude_patterns = ["./.git/*"],
+    exclude_patterns = [
+        "./.git/*",
+        "./.ijwb/*",
+    ],
     lint_mode = "warn",
     mode = "fix",
 )
 
 buildifier_test(
     name = "buildifier_test",
-    exclude_patterns = ["./.git/*"],
+    exclude_patterns = [
+        "./.git/*",
+        "./.ijwb/*",
+    ],
     lint_mode = "warn",
     no_sandbox = True,
     workspace = "//:WORKSPACE",

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -30,6 +30,27 @@ be used to extract the image manifest.
 | <a id="oci_image-os"></a>os |  Used to extract a manifest from base if base is an index   | String | optional |  `""`  |
 
 
+<a id="oci_image_config"></a>
+
+## oci_image_config
+
+<pre>
+oci_image_config(<a href="#oci_image_config-name">name</a>, <a href="#oci_image_config-arch">arch</a>, <a href="#oci_image_config-image">image</a>, <a href="#oci_image_config-os">os</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="oci_image_config-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="oci_image_config-arch"></a>arch |  Used to extract config from image if image is an index   | String | optional |  `""`  |
+| <a id="oci_image_config-image"></a>image |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="oci_image_config-os"></a>os |  Used to extract config from image if image is an index   | String | optional |  `""`  |
+
+
 <a id="oci_image_index"></a>
 
 ## oci_image_index
@@ -98,6 +119,38 @@ Pushes a manifest or a list of manifests to an OCI registry.
 | <a id="oci_push-stamp"></a>stamp |  Whether to encode build information into the output. Possible values:<br><br>- `stamp = 1`: Always stamp the build information into the output, even in     [--nostamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) builds.     This setting should be avoided, since it is non-deterministic.     It potentially causes remote cache misses for the target and     any downstream actions that depend on the result. - `stamp = 0`: Never stamp, instead replace build information by constant values.     This gives good build result caching. - `stamp = -1`: Embedding of build information is controlled by the     [--[no]stamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) flag.     Stamped targets are not rebuilt unless their dependencies change.   | Integer | optional |  `-1`  |
 | <a id="oci_push-tag"></a>tag |  (optional) A tag to include in the target reference. This will not be included on child images.<br><br>Subject to [$(location)](https://bazel.build/reference/be/make-variables#predefined_label_variables) and ["Make variable"](https://bazel.build/reference/be/make-variabmes) substitution.<br><br>**Stamping**<br><br>You can use values produced by the workspace status command in your tag. To do this write a script that prints key-value pairs separated by spaces, e.g.<br><br><pre><code class="language-sh">#!/usr/bin/env bash&#10;echo "STABLE_KEY1 VALUE1"&#10;echo "STABLE_KEY2 VALUE2"</code></pre><br><br>You can reference these keys in `tag` using curly braces,<br><br><pre><code class="language-python">oci_push(&#10;    name = "push",&#10;    tag = "v1.0-{STABLE_KEY1}",&#10;)</code></pre>   | String | optional |  `""`  |
 | <a id="oci_push-x_meta_headers"></a>x_meta_headers |  (optional) A list of key/values to to be sent to the registry as headers with an X-Meta- prefix.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+
+
+<a id="generate_config_file_action"></a>
+
+## generate_config_file_action
+
+<pre>
+generate_config_file_action(<a href="#generate_config_file_action-ctx">ctx</a>, <a href="#generate_config_file_action-config_file">config_file</a>, <a href="#generate_config_file_action-image">image</a>, <a href="#generate_config_file_action-os">os</a>, <a href="#generate_config_file_action-arch">arch</a>)
+</pre>
+
+Generates a run action with that extracts an image's config file.
+
+In order to use this action, the calling rule _must_ register
+`@com_github_datadog_rules_oci//oci:toolchain` and the image
+must provide the `OCIDescriptor` and `OCILayout`  (this should
+not be an issue when using the `oci_image` rule).
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="generate_config_file_action-ctx"></a>ctx |  The current rules context   |  none |
+| <a id="generate_config_file_action-config_file"></a>config_file |  The file to write the config to   |  none |
+| <a id="generate_config_file_action-image"></a>image |  The image to extract the config from.   |  none |
+| <a id="generate_config_file_action-os"></a>os |  The os to extract the config for   |  none |
+| <a id="generate_config_file_action-arch"></a>arch |  The arch to extract the config for   |  none |
+
+**RETURNS**
+
+The config file named after the rule, os, and arch
 
 
 <a id="oci_image_layer"></a>

--- a/go/cmd/ocitool/BUILD.bazel
+++ b/go/cmd/ocitool/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "appendlayer_cmd.go",
+        "config_cmd.go",
         "createlayer_cmd.go",
         "desc_helpers.go",
         "digest_cmd.go",

--- a/go/cmd/ocitool/config_cmd.go
+++ b/go/cmd/ocitool/config_cmd.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/DataDog/rules_oci/go/pkg/ociutil"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli/v2"
+	"os"
+)
+
+// ConfigCmd writes a given layouts config.
+func ConfigCmd(c *cli.Context) error {
+	localProviders, err := LoadLocalProviders(c.StringSlice("layout"), "")
+	if err != nil {
+		return err
+	}
+
+	allLocalProviders := ociutil.MultiProvider(localProviders...)
+
+	// Read the base descriptor. Its unknown since we don't know if it's an image or index.
+	baseUnknownDesc, err := ociutil.ReadDescriptorFromFile(c.String("base"))
+	if err != nil {
+		return err
+	}
+
+	targetPlatform := ocispec.Platform{
+		OS:           c.String("os"),
+		Architecture: c.String("arch"),
+	}
+	targetPlatformMatch := platforms.Only(targetPlatform)
+
+	// Resolve the unknown descriptor into an image manifest
+	// If the descriptor is an index, match the requested platform.
+	var baseManifestDesc ocispec.Descriptor
+	if images.IsIndexType(baseUnknownDesc.MediaType) {
+		index, err := ociutil.ImageIndexFromProvider(c.Context, allLocalProviders, baseUnknownDesc)
+		if err != nil {
+			return err
+		}
+
+		baseManifestDesc, err = ociutil.ManifestFromIndex(index, targetPlatformMatch)
+		if err != nil {
+			return err
+		}
+
+		if !targetPlatformMatch.Match(*baseManifestDesc.Platform) {
+			return fmt.Errorf("invalid platform, expected %v, recieved %v", targetPlatform, *baseManifestDesc.Platform)
+		}
+	} else if images.IsManifestType(baseUnknownDesc.MediaType) {
+		baseManifestDesc = baseUnknownDesc
+
+		if ociutil.IsEmptyPlatform(baseManifestDesc.Platform) {
+			platform, err := ociutil.ResolvePlatformFromDescriptor(c.Context, allLocalProviders, baseManifestDesc)
+			if err != nil {
+				return fmt.Errorf("no platform for base: %w", err)
+			}
+			baseManifestDesc.Platform = &platform
+		}
+	} else {
+		return fmt.Errorf("unknown base image type %q", baseUnknownDesc.MediaType)
+	}
+
+	manifest, err := ociutil.ImageManifestFromProvider(c.Context, allLocalProviders, baseManifestDesc)
+	if err != nil {
+		return fmt.Errorf("no image manifest (%v) in store: %w", baseManifestDesc, err)
+	}
+
+	imageConfig, err := ociutil.ImageConfigFromProvider(c.Context, allLocalProviders, manifest.Config)
+	if err != nil {
+		return fmt.Errorf("no image config (%v) in store: %w", manifest.Config, err)
+	}
+
+	// Write the image config to the output file.
+	outConfig, err := os.Create(c.String("out-config"))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = outConfig.Close() }()
+
+	err = json.NewEncoder(outConfig).Encode(imageConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/cmd/ocitool/main.go
+++ b/go/cmd/ocitool/main.go
@@ -233,6 +233,27 @@ as described in https://github.com/opencontainers/image-spec/blob/main/image-lay
 			},
 		},
 		{
+			Name:        "config",
+			Description: "Fetch the config of an image based on the given input layout.",
+			Action:      ConfigCmd,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "base",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name: "os",
+				},
+				&cli.StringFlag{
+					Name: "arch",
+				},
+				&cli.StringFlag{
+					Name:     "out-config",
+					Required: true,
+				},
+			},
+		},
+		{
 			Name:   "push-blob",
 			Hidden: true,
 			Action: PushBlobCmd,

--- a/oci/BUILD.bazel
+++ b/oci/BUILD.bazel
@@ -37,11 +37,22 @@ bzl_library(
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        ":config",
         ":image",
         ":layer",
         ":oci_image_layout",
         ":pull",
         ":push",
+    ],
+)
+
+bzl_library(
+    name = "config",
+    srcs = ["config.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_datadog_rules_oci//oci:image",
+        "@com_github_datadog_rules_oci//oci:providers",
     ],
 )
 

--- a/oci/config.bzl
+++ b/oci/config.bzl
@@ -1,0 +1,78 @@
+""" config """
+
+load("@com_github_datadog_rules_oci//oci:image.bzl", "get_descriptor_file")
+load("@com_github_datadog_rules_oci//oci:providers.bzl", "OCIDescriptor", "OCILayout")
+
+def generate_config_file_action(ctx, config_file, image, os, arch):
+    """ Generates a run action with that extracts an image's config file.
+
+    In order to use this action, the calling rule _must_ register
+    `@com_github_datadog_rules_oci//oci:toolchain` and the image
+    must provide the `OCIDescriptor` and `OCILayout`  (this should
+    not be an issue when using the `oci_image` rule).
+
+    Args:
+        ctx: The current rules context
+        config_file: The file to write the config to
+        image: The image to extract the config from.
+        os: The os to extract the config for
+        arch: The arch to extract the config for
+
+    Returns:
+        The config file named after the rule, os, and arch
+    """
+    toolchain = ctx.toolchains["@com_github_datadog_rules_oci//oci:toolchain"]
+
+    base_desc = get_descriptor_file(ctx, image[OCIDescriptor])
+    base_layout = image[OCILayout]
+
+    ctx.actions.run(
+        executable = toolchain.sdk.ocitool,
+        arguments = [
+            "--layout={}".format(base_layout.blob_index.path),
+            "config",
+            "--base={}".format(base_desc.path),
+            "--os={}".format(os),
+            "--arch={}".format(arch),
+            "--out-config={}".format(config_file.path),
+        ],
+        inputs = [
+            base_desc,
+            base_layout.blob_index,
+        ] + base_layout.files.to_list(),
+        outputs = [
+            config_file,
+        ],
+    )
+
+    return config_file
+
+def _oci_image_config_impl(ctx):
+    config_file = ctx.actions.declare_file("{}.config.json".format(ctx.label.name))
+
+    return DefaultInfo(files = depset([
+        generate_config_file_action(ctx, config_file, ctx.attr.image, ctx.attr.os, ctx.attr.arch),
+    ]))
+
+oci_image_config_rule = struct(
+    implementation = _oci_image_config_impl,
+    attrs = {
+        "image": attr.label(
+            mandatory = True,
+            providers = [OCIDescriptor, OCILayout],
+        ),
+        "os": attr.string(
+            doc = "Used to extract config from image if image is an index",
+        ),
+        "arch": attr.string(
+            doc = "Used to extract config from image if image is an index",
+        ),
+    },
+    toolchains = ["@com_github_datadog_rules_oci//oci:toolchain"],
+)
+
+oci_image_config = rule(
+    implementation = oci_image_config_rule.implementation,
+    attrs = oci_image_config_rule.attrs,
+    toolchains = oci_image_config_rule.toolchains,
+)

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -1,5 +1,6 @@
 """ public API """
 
+load(":config.bzl", _generate_config_file_action = "generate_config_file_action", _oci_image_config = "oci_image_config")
 load(":image.bzl", _oci_image = "oci_image", _oci_image_index = "oci_image_index")
 load(":layer.bzl", _oci_image_layer = "oci_image_layer")
 load(":oci_image_layout.bzl", _oci_image_layout = "oci_image_layout")
@@ -10,6 +11,9 @@ oci_pull = _oci_pull
 oci_push = _oci_push
 
 oci_image = _oci_image
+oci_image_config = _oci_image_config
 oci_image_index = _oci_image_index
 oci_image_layer = _oci_image_layer
 oci_image_layout = _oci_image_layout
+
+generate_config_file_action = _generate_config_file_action

--- a/oci/image.bzl
+++ b/oci/image.bzl
@@ -227,4 +227,5 @@ oci_image = rule(
         ),
     },
     toolchains = ["@com_github_datadog_rules_oci//oci:toolchain"],
+    provides = [OCIDescriptor, OCILayout],
 )


### PR DESCRIPTION
Adds `config` cmd to `ocitool` (similar to `crane config`). Given a descriptor file and an OCI layout, enables writing the `config.json` file for a given manifest (or index) to a specific location. 