### PR TITLE
fix: Fix modes/owners and thread through platform

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -119,8 +119,8 @@ Creates a tarball and an OCI descriptor for it
 | <a id="oci_image_layer-directory"></a>directory |  Directory in the tarball to place the `files`   |  `None` |
 | <a id="oci_image_layer-files"></a>files |  List of files to include under `directory`   |  `None` |
 | <a id="oci_image_layer-file_map"></a>file_map |  Dictionary of file -> file location in tarball   |  `None` |
-| <a id="oci_image_layer-mode_map"></a>mode_map |  Dictionary of file location in tarball -> mode int (e.g. 0x755)   |  `None` |
-| <a id="oci_image_layer-owner_map"></a>owner_map |  Dictionary of file location in tarball -> ownership string (e.g. 'root:root')   |  `None` |
+| <a id="oci_image_layer-mode_map"></a>mode_map |  Dictionary of file location in tarball -> mode int (e.g. 0o755)   |  `None` |
+| <a id="oci_image_layer-owner_map"></a>owner_map |  Dictionary of file location in tarball -> owner:group string (e.g. '501:501')   |  `None` |
 | <a id="oci_image_layer-symlinks"></a>symlinks |  Dictionary of symlink -> target entries to place in the tarball   |  `None` |
 | <a id="oci_image_layer-kwargs"></a>kwargs |  Additional arguments to pass to the rule, e.g. tags or visibility   |  none |
 

--- a/go/cmd/ocitool/appendlayer_cmd.go
+++ b/go/cmd/ocitool/appendlayer_cmd.go
@@ -176,6 +176,7 @@ func AppendLayersCmd(c *cli.Context) error {
 		c.StringSlice("env"),
 		createdTimestamp,
 		entrypoint,
+		targetPlatform,
 	)
 	if err != nil {
 		return err

--- a/go/cmd/ocitool/createlayer_cmd_test.go
+++ b/go/cmd/ocitool/createlayer_cmd_test.go
@@ -10,9 +10,10 @@ func TestParseIntWorksAsExpected(t *testing.T) {
 		input    string
 		expected int64
 	}{
-		{input: "0x755", expected: 0x755},
-		{input: "1877", expected: 0x755},
-		{input: "0b11101010101", expected: 0x755},
+		{input: "0o755", expected: 0o755},
+		{input: "0b111101101", expected: 0o755},
+		{input: "493", expected: 0o755},
+		{input: "0x1ed", expected: 0o755},
 	} {
 		actual, err := strconv.ParseInt(tc.input, 0, 64)
 		if err != nil {

--- a/go/internal/tarutil/tarappend.go
+++ b/go/internal/tarutil/tarappend.go
@@ -2,52 +2,175 @@ package tarutil
 
 import (
 	"archive/tar"
+	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"strings"
 	"time"
 )
 
-// AppendFileToTarWriter appends a file (given as a filepath) to a tarfile
-// through the tarfile interface.
+const (
+	ownerRead    = 0o0400
+	ownerWrite   = 0o0200
+	ownerExecute = 0o0100
+
+	groupRead    = 0o0040
+	groupWrite   = 0o0020
+	groupExecute = 0o0010
+
+	otherRead    = 0o0004
+	otherWrite   = 0o0002
+	otherExecute = 0o0001
+
+	setuid = 0o4000
+	setgid = 0o2000
+	sticky = 0o1000
+
+	allSupportedBits = ownerRead | ownerWrite | ownerExecute | groupRead | groupWrite | groupExecute | otherRead | otherWrite | otherExecute | setuid | setgid | sticky
+)
+
 func AppendFileToTarWriter(
-	filePath string,
-	loc string,
-	mode int64,
-	uname,
-	gname string,
+	hostPath string,
+	tarPath string,
+	tarMode int64,
+	tarUid,
+	tarGid *int,
 	tw *tar.Writer,
 ) error {
-	f, err := os.Open(filePath)
+	f, err := os.Open(hostPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("error opening file %s: %w", hostPath, err)
 	}
 	defer f.Close()
 
-	fi, err := f.Stat()
+	s, err := f.Stat()
 	if err != nil {
-		return err
+		return fmt.Errorf("error stating file %s: %w", hostPath, err)
 	}
 
-	hdr, err := tar.FileInfoHeader(fi, "")
-	if err != nil {
-		return err
+	m := s.Mode()
+
+	h := baseHeader(
+		/* defaultName */ tarPath,
+		/* defaultMode */ int64(m)&allSupportedBits,
+	)
+
+	switch {
+	case m.IsRegular():
+		h.Typeflag = tar.TypeReg
+		h.Size = s.Size()
+	case s.IsDir():
+		h.Typeflag = tar.TypeDir
+		h.Name = ensureTrailingSlash(tarPath)
+		h.Size = 0
+	case m.Type() == fs.ModeSymlink:
+		h.Typeflag = tar.TypeSymlink
+		linkName, err := os.Readlink(hostPath)
+		if err != nil {
+			return fmt.Errorf("error reading symlink %s: %w", hostPath, err)
+		}
+		h.Linkname = linkName
+		h.Size = 0
+	case m.Type() == fs.ModeDevice:
+		h.Typeflag = tar.TypeBlock
+		h.Size = 0
+	case m.Type() == fs.ModeCharDevice:
+		h.Typeflag = tar.TypeChar
+		h.Size = 0
+	case m.Type() == fs.ModeNamedPipe:
+		h.Typeflag = tar.TypeFifo
+		h.Size = 0
+	case m.Type() == fs.ModeSocket:
+		return fmt.Errorf("archive/tar: sockets not supported")
+	default:
+		return fmt.Errorf("archive/tar: unknown file mode %v", m)
 	}
 
-	hdr.AccessTime = time.Time{}
-	hdr.ChangeTime = time.Time{}
-	hdr.Gname = gname
-	hdr.ModTime = time.Time{}
-	hdr.Mode = mode
-	hdr.Uname = uname
+	updateMode(h, tarMode)
+	updateUid(h, tarUid)
+	updateGid(h, tarGid)
 
-	hdr.Name = loc
-
-	if err := tw.WriteHeader(hdr); err != nil {
-		return err
+	if err := tw.WriteHeader(h); err != nil {
+		return fmt.Errorf("error writing tar header for %s: %w", hostPath, err)
 	}
-	if _, err := io.Copy(tw, f); err != nil {
-		return err
+
+	if m.IsRegular() {
+		if _, err := io.Copy(tw, f); err != nil {
+			return fmt.Errorf("error writing %s into tarball: %w", hostPath, err)
+		}
 	}
 
 	return nil
+}
+
+func AppendSymlinkToTarWriter(
+	tarPath string,
+	tarTarget string,
+	tarMode int64,
+	tarUid,
+	tarGid *int,
+	tw *tar.Writer,
+) error {
+	h := baseHeader(
+		/* defaultName */ tarPath,
+		/* defaultMode */ 0o777,
+	)
+
+	h.Typeflag = tar.TypeSymlink
+	h.Linkname = tarTarget
+	h.Size = 0
+
+	updateMode(h, tarMode)
+	updateUid(h, tarUid)
+	updateGid(h, tarGid)
+
+	if err := tw.WriteHeader(h); err != nil {
+		return fmt.Errorf("error writing tar header for symlink %s: %w", tarPath, err)
+	}
+
+	return nil
+}
+
+func baseHeader(defaultName string, defaultMode int64) *tar.Header {
+	return &tar.Header{
+		Name: defaultName,
+
+		AccessTime: time.Unix(0, 0),
+		ChangeTime: time.Unix(0, 0),
+		ModTime:    time.Unix(0, 0),
+
+		Mode: defaultMode,
+
+		Gid: 0,
+		Uid: 0,
+	}
+}
+
+func ensureTrailingSlash(s string) string {
+	if !strings.HasSuffix(s, "/") {
+		return s + "/"
+	}
+	return s
+}
+
+func updateMode(h *tar.Header, mode int64) {
+	if mode == 0 {
+		return
+	}
+	h.Mode = mode
+}
+
+func updateUid(h *tar.Header, uid *int) {
+	if uid == nil {
+		return
+	}
+	h.Uid = *uid
+}
+
+func updateGid(h *tar.Header, gid *int) {
+	if gid == nil {
+		return
+	}
+	h.Gid = *gid
 }

--- a/go/pkg/ociutil/json.go
+++ b/go/pkg/ociutil/json.go
@@ -48,15 +48,24 @@ func ProviderJSONDecode(ctx context.Context, provider content.Provider, desc oci
 }
 
 // IngestorJSONEncode encodes json and saves it to a ingester.
-func IngestorJSONEncode(ctx context.Context, ing content.Ingester, mediaType string, inf interface{}) (ocispec.Descriptor, error) {
+func IngestorJSONEncode(
+	ctx context.Context,
+	ing content.Ingester,
+	annotations map[string]string,
+	mediaType string,
+	inf interface{},
+	platform *ocispec.Platform,
+) (ocispec.Descriptor, error) {
 	data, err := json.Marshal(inf)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("unable to marshal JSON: %w", err)
 	}
 	desc := ocispec.Descriptor{
-		MediaType: mediaType,
-		Size:      int64(len(data)),
-		Digest:    digest.SHA256.FromBytes(data),
+		Annotations: annotations,
+		Digest:      digest.SHA256.FromBytes(data),
+		MediaType:   mediaType,
+		Platform:    platform,
+		Size:        int64(len(data)),
 	}
 
 	writer, err := ing.Writer(ctx, content.WithDescriptor(desc))

--- a/oci/layer.bzl
+++ b/oci/layer.bzl
@@ -19,8 +19,8 @@ def oci_image_layer(
         directory: Directory in the tarball to place the `files`
         files: List of files to include under `directory`
         file_map: Dictionary of file -> file location in tarball
-        mode_map: Dictionary of file location in tarball -> mode int (e.g. 0x755)
-        owner_map: Dictionary of file location in tarball -> ownership string (e.g. 'root:root')
+        mode_map: Dictionary of file location in tarball -> mode int (e.g. 0o755)
+        owner_map: Dictionary of file location in tarball -> owner:group string (e.g. '501:501')
         symlinks: Dictionary of symlink -> target entries to place in the tarball
         **kwargs: Additional arguments to pass to the rule, e.g. tags or visibility
     """


### PR DESCRIPTION
There are two commits in this PR. Review them separately.

* Commit 1: Thread platform information through the descriptor files.
* Commit 2: Be much more precise about mode/owners. We don't want macos perm bits sneaking through to linux, plus other cleanups to be much more precise about this