### PR TITLE
Bump `setup-bazelisk` to `v3`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: bazelbuild/setup-bazelisk@v1
+      - uses: bazelbuild/setup-bazelisk@v3
 
       # Setup Credential Helper to authenticate to Github Container Registry
       - run: echo '{"credHelpers":{"ghcr.io":"ghcr"}}' > ~/.docker/config.json


### PR DESCRIPTION
Bump `setup-bazelisk` to v3

`v1` is not working: https://github.com/DataDog/rules_oci/actions/runs/14758062168/job/41431414276?pr=88