### PR TITLE
Update MODULE.bazel: Add zlib as dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ bazel_dep(name = "gazelle", version = "0.43.0")
 bazel_dep(name = "rules_go", version = "0.54.0")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 bazel_dep(name = "stardoc", version = "0.8.0")
+bazel_dep(name = "zlib", version = "1.3.1")
 
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.7.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "8.0.3", dev_dependency = True)


### PR DESCRIPTION
Add bazel_dep(name = "zlib", version = "1.3.1")

It's needed. Without it `bzl test //...` is failing on Mac.