### PR TITLE
Add mnemonics to all run/run_shell actions

### DIFF
--- a/oci/config.bzl
+++ b/oci/config.bzl
@@ -36,6 +36,7 @@ def generate_config_file_action(ctx, config_file, image, os, arch):
             "--arch={}".format(arch),
             "--out-config={}".format(config_file.path),
         ],
+        mnemonic = "OCIImageConfig",
         inputs = [
             base_desc,
             base_layout.blob_index,

--- a/oci/image.bzl
+++ b/oci/image.bzl
@@ -52,6 +52,7 @@ def _oci_image_index_impl(ctx):
                     ] +
                     ["--desc={}".format(d.path) for d in desc_files] +
                     ["--annotations={}={}".format(k, v) for k, v in ctx.attr.annotations.items()],
+        mnemonic = "OCImageCreateIndex",
         inputs = desc_files + layout_files.to_list(),
         outputs = outputs,
     )
@@ -153,6 +154,7 @@ def _oci_image_impl(ctx):
                  ] + ctx.files.layers +
                  layer_descriptor_files +
                  base_layout.files.to_list(),
+        mnemonic = "OCIImageAppendLayers",
         outputs = [
             manifest_file,
             config_file,

--- a/oci/layer.bzl
+++ b/oci/layer.bzl
@@ -57,6 +57,7 @@ def _impl(ctx):
                     ["--owner-map={}={}".format(k, v) for k, v in ctx.attr.owner_map.items()] +
                     ["--symlink={}={}".format(k, v) for k, v in ctx.attr.symlinks.items()],
         inputs = ctx.files.files + ctx.files.file_map,
+        mnemonic = "OCIImageCreateLayer",
         outputs = [
             descriptor_file,
             ctx.outputs.layer,

--- a/oci/oci_image_layout.bzl
+++ b/oci/oci_image_layout.bzl
@@ -39,6 +39,7 @@ def _oci_image_layout_impl(ctx):
         outputs = [
             out_dir,
         ],
+        mnemonic = "OCIImageCreateLayout",
         use_default_shell_env = True,
     )
 

--- a/oci/push.bzl
+++ b/oci/push.bzl
@@ -42,6 +42,7 @@ def _oci_push_impl(ctx):
             outputs = [
                 tag_file,
             ],
+            mnemonic = "OCIPushStamp",
             arguments = [args],
             command = """#!/usr/bin/env bash
 scratch=$(cat $1)
@@ -71,6 +72,7 @@ done
             "--desc={desc}".format(desc = ctx.attr.manifest[OCIDescriptor].descriptor_file.path),
             "--out={out}".format(out = digest_file.path),
         ],
+        mnemonic = "OCIPushDigest",
         inputs = [
             ctx.attr.manifest[OCIDescriptor].descriptor_file,
         ],


### PR DESCRIPTION
Hooked on mnemonics worked for me!

---

This PR simply adds mnemonics to all `ctx.actions.run ` /  `ctx.actions.run_shell` actions. I followed the rough convention of `RuleNameCommand` (`OCIImageConfig`, `OCIImageAppendLayers`, etc...). 