### PR TITLE
LANGTOOLS-3302 Add output groups for `oci_push`

### DIFF
--- a/oci/push.bzl
+++ b/oci/push.bzl
@@ -133,6 +133,10 @@ done
             digest = digest_file,
             tag_file = tag_file,
         ),
+        OutputGroupInfo(
+            digest_file = depset([digest_file]),
+            tag_file = depset([tag_file]),
+        ),
     ]
 
 oci_push = rule(


### PR DESCRIPTION
## Context

Jira Issue: https://datadoghq.atlassian.net/browse/LANGTOOLS-3302

We want a way to easily grab the `digest_file` from an `oci_push` rule. [Output groups](https://bazel.build/extending/rules#requesting_output_files) are exactly that way. We can workaround it with a `cquery` and some fancy Starlark stuff, but it's also easier if we just say `bzl <command> --output_groups=digest_file`.

We also add the `tag_file` as an output group while we're here. We don't know for sure that we'll need it right away, but it's likely we'll want it, and adding it is cheap to do now.