### PR TITLE
LANGTOOLS Fix push-rules command

### DIFF
--- a/go/pkg/ociutil/push.go
+++ b/go/pkg/ociutil/push.go
@@ -216,14 +216,18 @@ func (resolver Resolver) MarshalAndPushContent(ctx context.Context, ref string, 
 		}
 		return desc, fmt.Errorf("unable to build pusher writer: %w", err)
 	}
+
+	defer func() {
+		if err := w.Close(); err != nil {
+			log.Errorf("Unable to close writer: %v", err)
+		}
+	}()
+
 	_, err = w.Write(contents)
 	if err != nil {
 		return desc, fmt.Errorf("unable to push image: %w", err)
 	}
-	err = w.Close()
-	if err != nil {
-		return desc, fmt.Errorf("unable to close writer: %w", err)
-	}
+
 	log.Debug("contents pushed")
 
 	err = w.Commit(ctx, desc.Size, desc.Digest)


### PR DESCRIPTION
## Context

The previous behavior had us closing the writer immediately after writing, and then attempting to commit with the closed writer. This behavior would sometimes lead to errors like:
```Console
$ bazel run //go/cmd/ocitool push-rules -- --ref <reference> --file $(bazel info bazel-bin)/release/release.tar.gz
<snip>
unable to commit: io: read/write on closed pipe
```

That cryptic error was from the previous behavior explained.

We switch things around to defer closing until the function exits, so that we don't attempt to commit an already closed writer.

## Testing

We validated this works by running it, and seeing it succeed where before it was regularly failing:
```Console
$ bazel run //go/cmd/ocitool -- push-rules --ref <reference> --file $(bazel info bazel-bin)/release/release.tar.gz
<snip>
Pushed: <reference>
```