### PR TITLE
Add support for CMD in addition to ENTRYPOINT

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -142,7 +142,7 @@ The config file named after the rule, os, and arch
 <pre>
 load("@rules_oci//oci:defs.bzl", "oci_image")
 
-oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-base">base</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-arch">arch</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-layers">layers</a>, <a href="#oci_image-os">os</a>, <a href="#oci_image-tars">tars</a>, <a href="#oci_image-kwargs">kwargs</a>)
+oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-base">base</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-arch">arch</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-layers">layers</a>, <a href="#oci_image-os">os</a>, <a href="#oci_image-tars">tars</a>, <a href="#oci_image-kwargs">kwargs</a>)
 </pre>
 
 oci_image
@@ -161,7 +161,8 @@ index, then `os` and `arch` will be used to extract the image manifest.
 | <a id="oci_image-base"></a>base |  A base image, as defined by oci_pull or oci_image.   |  none |
 | <a id="oci_image-annotations"></a>annotations |  OCI Annotations to add to the manifest.   |  `None` |
 | <a id="oci_image-arch"></a>arch |  Used to extract a manifest from base if base is an index.   |  `None` |
-| <a id="oci_image-entrypoint"></a>entrypoint |  A list of entrypoints for the image; these will be inserted into the generated container configuration.   |  `None` |
+| <a id="oci_image-cmd"></a>cmd |  Default arguments to the entrypoint of the container. If an Entrypoint value is not specified, then the first entry of the Cmd array will be interpreted as the executable to run   |  `None` |
+| <a id="oci_image-entrypoint"></a>entrypoint |  A list of arguments to use as the command to execute when the container starts; these will be inserted into the generated OCI image config   |  `None` |
 | <a id="oci_image-env"></a>env |  Entries are in the format of `VARNAME=VARVALUE`. These values act as defaults and are merged with any specified when creating a container.   |  `None` |
 | <a id="oci_image-labels"></a>labels |  Labels that will be applied to the image configuration, as defined in the OCI config. These behave the same way as docker LABEL. In particular, labels from the base image are inherited. An empty value for a label will cause that label to be deleted. For backwards compatibility, if this is not set, then the value of annotations will be used instead.   |  `None` |
 | <a id="oci_image-layers"></a>layers |  A list of layers defined by oci_image_layer.   |  `None` |

--- a/go/cmd/ocitool/appendlayer_cmd.go
+++ b/go/cmd/ocitool/appendlayer_cmd.go
@@ -207,6 +207,18 @@ func AppendLayersCmd(c *cli.Context) error {
 		layerDescs = append(layerDescs, tarDesc)
 	}
 
+	var cmd *[]string
+	if cmdPath := c.String("cmd"); cmdPath != "" {
+		var cmdStruct struct {
+			Cmd []string `json:"cmd"`
+		}
+		err := jsonutil.DecodeFromFile(cmdPath, &cmdStruct)
+		if err != nil {
+			return fmt.Errorf("failed to read cmd config file: %w", err)
+		}
+		cmd = &cmdStruct.Cmd
+	}
+
 	var entrypoint *[]string
 	if entrypointPath := c.String("entrypoint"); entrypointPath != "" {
 		var entrypointStruct struct {
@@ -230,6 +242,7 @@ func AppendLayersCmd(c *cli.Context) error {
 		c.Generic("labels").(*flagutil.KeyValueFlag).Map,
 		c.StringSlice("env"),
 		createdTimestamp,
+		cmd,
 		entrypoint,
 		targetPlatform,
 	)

--- a/go/cmd/ocitool/main.go
+++ b/go/cmd/ocitool/main.go
@@ -131,6 +131,9 @@ var app = &cli.App{
 					Name: "out-layout",
 				},
 				&cli.StringFlag{
+					Name: "cmd",
+				},
+				&cli.StringFlag{
 					Name: "entrypoint",
 				},
 			},

--- a/go/pkg/layer/append.go
+++ b/go/pkg/layer/append.go
@@ -28,6 +28,7 @@ func AppendLayers(
 	labels map[string]string,
 	env []string,
 	created time.Time,
+	cmd *[]string,
 	entrypoint *[]string,
 	platform ocispec.Platform,
 ) (ocispec.Descriptor, ocispec.Descriptor, error) {
@@ -136,6 +137,9 @@ func AppendLayers(
 	imageConfig.History = append(imageConfig.History, history...)
 
 	imageConfig.Author = "rules_oci"
+	if cmd != nil {
+		imageConfig.Config.Cmd = *cmd
+	}
 	if entrypoint != nil {
 		imageConfig.Config.Entrypoint = *entrypoint
 	}


### PR DESCRIPTION
OCI supports both. We should support both.

This is especially useful for _removing_ `CMD` if it is set in base
images.

Previously there was no way to do this and it would always be appended
to whatever `ENTRYPOINT` the image had (per OCI spec)