### PR TITLE
Do not set gzipWriter.Name

### DIFF
--- a/go/cmd/ocitool/createlayer_cmd.go
+++ b/go/cmd/ocitool/createlayer_cmd.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -44,7 +43,6 @@ func CreateLayerCmd(c *cli.Context) error {
 	switch config.CompressionMethod {
 	case "gzip":
 		gzipWriter := gzip.NewWriter(wc)
-		gzipWriter.Name = path.Base(out.Name())
 		compressWriter = gzipWriter
 		compressCloser = gzipWriter
 		mediaType = ocispec.MediaTypeImageLayerGzip


### PR DESCRIPTION
When dd_oci_image builds FIPS and non-FIPS variants, they get different target names (.fips. vs .internal.), which means the output filenames differ. The gzip blobs end up 4 bytes apart in the header despite having byte-identical content, so the registry sees different SHA256 digests and can't deduplicate them. 

The FNAME field is optional per RFC 1952, and Go's gzip.Writer omits it when Name is empty (the default). Nobody downstream reads it — OCI registries identify layers by digest.