### PR TITLE
[auth] Fix Bearer credential helper sending Basic auth (400 on image pull)

### DIFF
--- a/go/pkg/credhelper/docker.go
+++ b/go/pkg/credhelper/docker.go
@@ -99,15 +99,20 @@ func seedAuthHeaders(host docker.RegistryHost) error {
 	return nil
 }
 
-// staticBearerTransport injects a pre-issued Bearer token into every request,
-// bypassing the standard Docker token-exchange flow.
-type staticBearerTransport struct {
+// bearerAuthFixTransport intercepts requests where containerd has set
+// Authorization: Basic base64("Bearer:<JWT>") (from a credential helper returning
+// Username="Bearer") and converts them to Authorization: Bearer <JWT>.
+// This allows the token endpoint to issue a proper scope-specific token, which
+// containerd then uses for all subsequent registry requests (manifests and blobs).
+type bearerAuthFixTransport struct {
 	token string
 }
 
-func (t *staticBearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *bearerAuthFixTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	clone := req.Clone(req.Context())
-	clone.Header.Set("Authorization", "Bearer "+t.token)
+	if username, _, ok := clone.BasicAuth(); ok && username == "Bearer" {
+		clone.Header.Set("Authorization", "Bearer "+t.token)
+	}
 	return http.DefaultTransport.RoundTrip(clone)
 }
 
@@ -146,13 +151,30 @@ func RegistryHostsFromDockerConfig() docker.RegistryHosts {
 
 		if creds.Username == "Bearer" {
 			// The credential helper returned a pre-issued Bearer token (Username=="Bearer",
-			// Secret==<JWT>). Sending this as Basic auth to the token endpoint produces a
-			// 400 Bad Request, so we inject it directly as a static Authorization header
-			// via a custom transport, bypassing the token-exchange flow entirely.
-			registryHost.Client = &http.Client{
-				Transport: &staticBearerTransport{token: creds.Secret},
+			// Secret==<JWT>). containerd's WithAuthCreds flow would construct
+			// Authorization: Basic base64("Bearer:<JWT>") for the token endpoint, which
+			// the registry rejects with 400 Bad Request.
+			//
+			// Fix: use a custom transport that converts Basic("Bearer", <JWT>) →
+			// Bearer <JWT> on the wire. This lets the token endpoint issue a proper
+			// scope-specific token, which containerd then uses for all registry requests
+			// (manifests and blobs).
+			customClient := &http.Client{
+				Transport: &bearerAuthFixTransport{token: creds.Secret},
 			}
-			// Authorizer is nil: seedAuthHeaders is a no-op and no token exchange occurs.
+			registryHost.Client = customClient
+			registryHost.Authorizer = docker.NewDockerAuthorizer(
+				docker.WithAuthCreds(func(host string) (string, string, error) {
+					return creds.Username, creds.Secret, nil
+				}),
+				docker.WithAuthClient(customClient),
+			)
+
+			err = seedAuthHeaders(registryHost)
+			if err != nil {
+				return nil, err
+			}
+
 			return []docker.RegistryHost{registryHost}, nil
 		}
 

--- a/go/pkg/credhelper/docker.go
+++ b/go/pkg/credhelper/docker.go
@@ -99,6 +99,18 @@ func seedAuthHeaders(host docker.RegistryHost) error {
 	return nil
 }
 
+// staticBearerTransport injects a pre-issued Bearer token into every request,
+// bypassing the standard Docker token-exchange flow.
+type staticBearerTransport struct {
+	token string
+}
+
+func (t *staticBearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+t.token)
+	return http.DefaultTransport.RoundTrip(clone)
+}
+
 func RegistryHostsFromDockerConfig() docker.RegistryHosts {
 	return func(host string) ([]docker.RegistryHost, error) {
 		// FIXME This should be cached somewhere
@@ -126,14 +138,25 @@ func RegistryHostsFromDockerConfig() docker.RegistryHosts {
 			return []docker.RegistryHost{registryHost}, nil
 		}
 
-		registryHost.Authorizer = docker.NewDockerAuthorizer(docker.WithAuthCreds(func(host string) (string, string, error) {
-			p := helperclient.NewShellProgramFunc(fmt.Sprintf("docker-credential-%s", helperName))
+		p := helperclient.NewShellProgramFunc(fmt.Sprintf("docker-credential-%s", helperName))
+		creds, err := helperclient.Get(p, fmt.Sprintf("%s://%s", registryHost.Scheme, registryHost.Host))
+		if err != nil {
+			return nil, err
+		}
 
-			creds, err := helperclient.Get(p, fmt.Sprintf("%s://%s", registryHost.Scheme, registryHost.Host))
-			if err != nil {
-				return "", "", err
+		if creds.Username == "Bearer" {
+			// The credential helper returned a pre-issued Bearer token (Username=="Bearer",
+			// Secret==<JWT>). Sending this as Basic auth to the token endpoint produces a
+			// 400 Bad Request, so we inject it directly as a static Authorization header
+			// via a custom transport, bypassing the token-exchange flow entirely.
+			registryHost.Client = &http.Client{
+				Transport: &staticBearerTransport{token: creds.Secret},
 			}
+			// Authorizer is nil: seedAuthHeaders is a no-op and no token exchange occurs.
+			return []docker.RegistryHost{registryHost}, nil
+		}
 
+		registryHost.Authorizer = docker.NewDockerAuthorizer(docker.WithAuthCreds(func(host string) (string, string, error) {
 			return creds.Username, creds.Secret, nil
 		}))
 


### PR DESCRIPTION
## Motivation & Context

- **Problem:** When a `credHelper` in `~/.docker/config.json` returns `Username="Bearer"` / `Secret="<JWT>"` (as `ddtool` does), `ocitool`'s `RegistryHostsFromDockerConfig` passes them to `WithAuthCreds`, which sends `Authorization: Basic base64("Bearer:<JWT>")` to the token endpoint. The registry rejects this with **400 Bad Request**.
- **Goal:** Fix `ocitool` image pulls for users whose `~/.docker/config.json` has `registry.ddbuild.io` in `credHelpers` (not just `credsStore`).
- **Background:** Same root cause as DataDog/rules_oci_bootstrap#13, which fixed blob pulls in `rules_oci_bootstrap`. This fixes the equivalent bug in `ocitool`'s OCI image pull path used for building Docker images in `dd-source`.

## Change Summary

- `go/pkg/credhelper/docker.go`: call `helperclient.Get` before setting up the authorizer; if `creds.Username == "Bearer"`, inject the JWT directly as `Authorization: Bearer` via a `staticBearerTransport` (custom `http.RoundTripper`), bypassing the token-exchange flow entirely
- Non-Bearer credentials continue through the existing `WithAuthCreds` path unchanged

## Auth flow — before vs. after

**Before (broken):**
```
ocitool → ddtool get registry.ddbuild.io → Username="Bearer", Secret="<JWT>"
ocitool → registry (manifest): Authorization: Basic base64("Bearer:<JWT>") → 401
ocitool → token endpoint (GET): Authorization: Basic base64("Bearer:<JWT>") → 400 ❌
```

**After (fixed):**
```
ocitool → ddtool get registry.ddbuild.io → Username="Bearer", Secret="<JWT>"
ocitool → registry (manifest): Authorization: Bearer <JWT> → 200 ✅
```

## Testing

- `go build ./go/pkg/credhelper/...` passes
- Manually verified on an affected machine: `bzl build` targets that pull base images (`go_image_base_oci`, `gbi-ubuntu_2204`, `gbi-distroless`) succeed after this fix

---
🤖 This PR was authored with assistance from [Claude Code](https://claude.com/claude-code) AI