### PR TITLE
credhelper: add static-Bearer mode

### DIFF
--- a/go/pkg/credhelper/BUILD.bazel
+++ b/go/pkg/credhelper/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -12,4 +12,10 @@ go_library(
         "@com_github_mitchellh_go_homedir//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
+)
+
+go_test(
+    name = "credhelper_test",
+    srcs = ["docker_test.go"],
+    embed = [":go_default_library"],
 )

--- a/go/pkg/credhelper/docker.go
+++ b/go/pkg/credhelper/docker.go
@@ -126,9 +126,19 @@ func RegistryHostsFromDockerConfig() docker.RegistryHosts {
 			return []docker.RegistryHost{registryHost}, nil
 		}
 
-		registryHost.Authorizer = docker.NewDockerAuthorizer(docker.WithAuthCreds(func(host string) (string, string, error) {
-			p := helperclient.NewShellProgramFunc(fmt.Sprintf("docker-credential-%s", helperName))
+		// Probe the helper once. If it returns the static-Bearer sentinel,
+		// install Authorization on the host directly and skip the docker
+		// challenge-response auth flow entirely. Without this, helpers that
+		// return a raw bearer token (e.g. an environment-provided identity
+		// token) get routed through Basic auth or an OAuth2 token exchange,
+		// which doesn't match what the registry expects.
+		p := helperclient.NewShellProgramFunc(fmt.Sprintf("docker-credential-%s", helperName))
+		if creds, err := helperclient.Get(p, fmt.Sprintf("%s://%s", registryHost.Scheme, registryHost.Host)); err == nil && creds.Username == staticBearerSentinel {
+			registryHost.Header = http.Header{"Authorization": []string{"Bearer " + creds.Secret}}
+			return []docker.RegistryHost{registryHost}, nil
+		}
 
+		registryHost.Authorizer = docker.NewDockerAuthorizer(docker.WithAuthCreds(func(host string) (string, string, error) {
 			creds, err := helperclient.Get(p, fmt.Sprintf("%s://%s", registryHost.Scheme, registryHost.Host))
 			if err != nil {
 				return "", "", err
@@ -145,3 +155,15 @@ func RegistryHostsFromDockerConfig() docker.RegistryHosts {
 		return []docker.RegistryHost{registryHost}, nil
 	}
 }
+
+// staticBearerSentinel is the value a docker-credential helper sets in its
+// Username field to opt into static-Bearer mode: the helper's Secret is
+// applied as a literal "Authorization: Bearer <Secret>" header on every
+// request to the registry, and the challenge-response auth flow is skipped.
+//
+// This is the docker-credential-helpers analogue of go-containerregistry's
+// "<token>" username convention, but tighter — go-containerregistry's
+// "<token>" still goes through an OAuth2 refresh_token exchange against the
+// challenge realm, which we don't want when the upstream accepts the token
+// directly as a bearer.
+const staticBearerSentinel = "<static_bearer>"

--- a/go/pkg/credhelper/docker_test.go
+++ b/go/pkg/credhelper/docker_test.go
@@ -1,0 +1,88 @@
+package credhelper
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// writeHelperOnPath writes a fake docker-credential-<name> shell script onto
+// PATH that emits the given username and secret as a docker-credential-helper
+// Get response. Returns the helper name.
+func writeHelperOnPath(t *testing.T, username, secret string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell helper not portable to windows")
+	}
+
+	binDir := t.TempDir()
+	name := "credhelper-test"
+	script := "#!/bin/sh\ncat > /dev/null\n" +
+		`printf '{"ServerURL":"","Username":"` + username + `","Secret":"` + secret + `"}\n'` + "\n"
+	helperPath := filepath.Join(binDir, "docker-credential-"+name)
+	if err := os.WriteFile(helperPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+
+	orig := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+orig)
+	return name
+}
+
+// writeDockerConfig writes a docker config.json in a temp dir, points
+// DOCKER_CONFIG at it, and maps the given host to the given credHelper name.
+// Setting DOCKER_CONFIG explicitly sidesteps homedir.Dir caching between tests.
+func writeDockerConfig(t *testing.T, host, helperName string) {
+	t.Helper()
+
+	dockerDir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dockerDir)
+
+	cfg := map[string]any{
+		"credHelpers": map[string]string{
+			host: helperName,
+		},
+	}
+	body, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), body, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// TestRegistryHostsStaticBearerSentinel verifies that a docker-credential
+// helper returning the "<bearer>" sentinel username produces a RegistryHost
+// with a static "Authorization: Bearer <Secret>" header and no Authorizer —
+// so the challenge-response auth flow is skipped entirely.
+func TestRegistryHostsStaticBearerSentinel(t *testing.T) {
+	const host = "registry.example.com"
+	const token = "tok-abc-123"
+
+	helperName := writeHelperOnPath(t, staticBearerSentinel, token)
+	writeDockerConfig(t, host, helperName)
+
+	hosts, err := RegistryHostsFromDockerConfig()(host)
+	if err != nil {
+		t.Fatalf("RegistryHostsFromDockerConfig: %v", err)
+	}
+	if len(hosts) != 1 {
+		t.Fatalf("want 1 host, got %d", len(hosts))
+	}
+	h := hosts[0]
+
+	if got := h.Header.Get("Authorization"); got != "Bearer "+token {
+		t.Errorf("Header[Authorization] = %q, want %q", got, "Bearer "+token)
+	}
+	if h.Authorizer != nil {
+		t.Errorf("Authorizer must be nil in static-Bearer mode; got %T", h.Authorizer)
+	}
+}
+
+// Note: the non-sentinel (challenge-response) branch is not exercised here
+// because seedAuthHeaders hardcodes https:// and does a network round-trip,
+// which is awkward to unit test. That code path is unchanged by this patch
+// and is covered by existing rules_oci integration usage.


### PR DESCRIPTION
## Summary

Add a static-Bearer authentication mode to `credhelper.RegistryHostsFromDockerConfig`. When a docker-credential helper returns `Username == "<static_bearer>"`, the helper's Secret is installed as a literal `Authorization: Bearer <Secret>` header on the `RegistryHost`, and the docker challenge-response auth flow is skipped entirely.

## Motivation

Some registries authenticate the caller via a pre-minted bearer token rather than an OAuth2 realm exchange. Concretely: Datadog's Terrapin Forwarder accepts the calling sandbox's identity JWT directly as a bearer, with no token endpoint to exchange against. Today, `RegistryHostsFromDockerConfig` always wires up a `docker.NewDockerAuthorizer` that runs the WWW-Authenticate challenge flow — either Basic-auth or OAuth2 token exchange — neither of which matches "send this token verbatim."

The new path mirrors go-containerregistry's `"<token>"` username convention, but tighter: `"<token>"` still goes through an OAuth2 refresh_token exchange against the challenge realm. `"<static_bearer>"` skips that and just sets the header.

## Behavior

- If the docker-credential helper for a host returns `Username: "<static_bearer>"`, the host is configured with:
  - `Header = http.Header{"Authorization": []string{"Bearer <Secret>"}}` — applied to every request via containerd's `RegistryHost.Header` merge (`remotes/docker/resolver.go`).
  - `Authorizer = nil` — challenge-response auth flow disabled.
- All other helper outputs use the existing challenge-response flow unchanged.

## Test plan

- [x] New unit test `TestRegistryHostsStaticBearerSentinel` covers the sentinel path: confirms the `Authorization: Bearer …` header is installed and the Authorizer is nil.
- [x] `bazel run //:bootstrap && bazel test //...` — **6/6 pass on this branch** (`buildifier_test`, `docs:update_test`, `go/cmd/ocitool:go_default_test`, `go/pkg/credhelper:credhelper_test`, `go/pkg/deb2layer:go_default_test`, `go/pkg/ociutil:go_default_test`).
- [x] End-to-end verified by building a patched `ocitool` and pulling a multi-arch image (`registry.ddbuild.io/images/compute-toolbox@sha256:d45510ad…`) through our forwarder proxy from inside a sandbox: manifest list → platform manifests → config + layer blobs all 200 OK. Without the patch the same flow gets `401 Unauthorized` because the forwarder's challenge isn't an OAuth2 token endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)