### PR TITLE
Fix the `oci_push` runfiles with the new transitive `blob_indices` support

### DIFF
--- a/oci/push.bzl
+++ b/oci/push.bzl
@@ -125,12 +125,14 @@ done
         is_executable = True,
     )
 
+    runfiles = ctx.runfiles(
+        files = [toolchain.sdk.ocitool, ctx.attr.manifest[OCIDescriptor].descriptor_file, digest_file, tag_file],
+        transitive_files = depset(transitive = [layout.files, layout.transitive_blob_indices]),
+    )
+
     return [
         DefaultInfo(
-            runfiles = ctx.runfiles(
-                files = layout.files.to_list() +
-                        [toolchain.sdk.ocitool, ctx.attr.manifest[OCIDescriptor].descriptor_file, digest_file, tag_file],
-            ),
+            runfiles = runfiles,
         ),
         OCIReferenceInfo(
             registry = ctx.attr.registry,


### PR DESCRIPTION
DataDog/rules_oci#141 forgot to add the new files to the runfiles... oops.

This breaks at build time with the following error:
```
failed to load layout (../python_3_12_8/layout.layout.json):
couldn't open index: open ../python_3_12_8/layout.layout.json: no such file or directory
```